### PR TITLE
Introduce AuthService for dependency injection

### DIFF
--- a/lib/pages/create_trip_page.dart
+++ b/lib/pages/create_trip_page.dart
@@ -1,4 +1,3 @@
-import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -7,6 +6,7 @@ import 'package:travel_genie/l10n/app_localizations.dart';
 
 import '../providers/trip_service_provider.dart';
 import '../providers/user_providers.dart';
+import '../services/auth_service.dart';
 import '../widgets/login_required_dialog.dart';
 
 class CreateTripPage extends ConsumerStatefulWidget {
@@ -72,7 +72,7 @@ class _CreateTripPageState extends ConsumerState<CreateTripPage> {
 
     // Check if user is authenticated
     try {
-      final user = FirebaseAuth.instance.currentUser;
+      final user = ref.read(authServiceProvider).currentUser;
       if (user == null) {
         // Show login required dialog
         if (mounted) {

--- a/lib/pages/groups_page.dart
+++ b/lib/pages/groups_page.dart
@@ -10,7 +10,8 @@ import '../widgets/groups/feedback_summary.dart';
 // Provider for groups service
 final groupsServiceProvider = Provider<GroupsService>((ref) {
   final firestoreService = ref.watch(user_providers.firestoreServiceProvider);
-  return GroupsService(firestoreService);
+  final authService = ref.watch(user_providers.authServiceProvider);
+  return GroupsService(firestoreService, authService);
 });
 
 final groupsFeedbackProvider = StreamProvider<Map<String, dynamic>?>((ref) {

--- a/lib/pages/my_trips_page.dart
+++ b/lib/pages/my_trips_page.dart
@@ -1,4 +1,3 @@
-import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -8,6 +7,7 @@ import '../providers/trip_service_provider.dart';
 import '../widgets/login_required_dialog.dart';
 import '../widgets/my_trips/empty_trip_state.dart';
 import '../widgets/my_trips/trip_list.dart';
+import '../services/auth_service.dart';
 
 /// Main page for displaying user's trips
 class MyTripsPage extends ConsumerWidget {
@@ -25,7 +25,7 @@ class MyTripsPage extends ConsumerWidget {
             if (trips.isEmpty) {
               // Check if user is authenticated
               try {
-                final user = FirebaseAuth.instance.currentUser;
+                final user = ref.read(authServiceProvider).currentUser;
                 if (user == null) {
                   // User is not authenticated, show login dialog
                   WidgetsBinding.instance.addPostFrameCallback((_) {
@@ -56,7 +56,7 @@ class MyTripsPage extends ConsumerWidget {
         onPressed: () async {
           // Check if user is authenticated before navigating to create trip
           try {
-            final user = FirebaseAuth.instance.currentUser;
+            final user = ref.read(authServiceProvider).currentUser;
             if (user == null) {
               // Show login required dialog
               await LoginRequiredDialog.show(context);

--- a/lib/pages/place_detail_page.dart
+++ b/lib/pages/place_detail_page.dart
@@ -1,4 +1,3 @@
-import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -15,6 +14,7 @@ import '../widgets/place_detail/image_carousel.dart';
 import '../widgets/place_detail/location_map_section.dart';
 import '../widgets/place_detail/photo_gallery.dart';
 import '../widgets/place_detail/place_info_section.dart';
+import '../services/auth_service.dart';
 
 class PlaceDetailPage extends ConsumerStatefulWidget {
   const PlaceDetailPage({super.key, required this.place, this.heroTagIndex});
@@ -42,7 +42,7 @@ class _PlaceDetailPageState extends ConsumerState<PlaceDetailPage> {
 
   void _getCurrentUser() {
     try {
-      final user = FirebaseAuth.instance.currentUser;
+      final user = ref.read(authServiceProvider).currentUser;
       if (user != null) {
         setState(() {
           _currentUserId = user.uid;
@@ -55,7 +55,7 @@ class _PlaceDetailPageState extends ConsumerState<PlaceDetailPage> {
 
   Future<void> _checkIfPlaceIsSaved() async {
     try {
-      final user = FirebaseAuth.instance.currentUser;
+      final user = ref.read(authServiceProvider).currentUser;
       if (user == null) return;
 
       setState(() {
@@ -110,7 +110,7 @@ class _PlaceDetailPageState extends ConsumerState<PlaceDetailPage> {
 
   Future<void> _toggleSaved() async {
     try {
-      final user = FirebaseAuth.instance.currentUser;
+      final user = ref.read(authServiceProvider).currentUser;
       if (user == null) {
         // Show login required dialog
         await LoginRequiredDialog.show(context);

--- a/lib/pages/profile_screen.dart
+++ b/lib/pages/profile_screen.dart
@@ -1,4 +1,3 @@
-import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -14,13 +13,14 @@ import '../widgets/profile/delete_account_tile.dart';
 import '../widgets/profile/language_settings_tile.dart';
 import '../widgets/profile/logout_tile.dart';
 import '../widgets/profile/traveler_profile_summary.dart';
+import '../services/auth_service.dart';
 
 class ProfileScreen extends ConsumerWidget {
   const ProfileScreen({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final user = FirebaseAuth.instance.currentUser;
+    final user = ref.watch(authServiceProvider).currentUser;
     final userData = ref.watch(userDataProvider).valueOrNull;
     final profileService = ref.watch(profileServiceProvider);
 

--- a/lib/providers/challenge_providers.dart
+++ b/lib/providers/challenge_providers.dart
@@ -1,10 +1,10 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
-import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../models/challenge.dart';
 import '../services/challenge_progress_service.dart';
 import '../services/challenge_service.dart';
+import '../services/auth_service.dart';
 
 /// Provider for ChallengeService
 final challengeServiceProvider = Provider<ChallengeService>((ref) {
@@ -44,7 +44,7 @@ final completedChallengesProvider = StreamProvider.family<List<String>, String>(
 final userChallengesWithProgressProvider = StreamProvider<List<Challenge>>((
   ref,
 ) {
-  final user = FirebaseAuth.instance.currentUser;
+  final user = ref.watch(authServiceProvider).currentUser;
 
   // For non-logged users, return only the create_account challenge
   if (user == null) {
@@ -63,7 +63,7 @@ final userChallengesWithProgressProvider = StreamProvider<List<Challenge>>((
 /// Provider for a specific challenge with user progress
 final challengeWithProgressProvider = StreamProvider.family<Challenge?, String>(
   (ref, challengeId) {
-    final user = FirebaseAuth.instance.currentUser;
+    final user = ref.watch(authServiceProvider).currentUser;
 
     // For non-logged users, only return create_account challenge
     if (user == null) {

--- a/lib/providers/trip_service_provider.dart
+++ b/lib/providers/trip_service_provider.dart
@@ -14,8 +14,14 @@ import 'day_summary_service_provider.dart';
 final tripServiceProvider = Provider<TripService>((ref) {
   final firestoreService = ref.watch(firestoreServiceProvider);
   final daySummaryService = ref.watch(daySummaryServiceProvider);
+  final authService = ref.watch(authServiceProvider);
   final locale = ref.watch(localeProvider);
-  return TripService(firestoreService, daySummaryService, locale?.languageCode);
+  return TripService(
+    firestoreService,
+    daySummaryService,
+    authService,
+    locale?.languageCode,
+  );
 });
 
 /// Provider that exposes a stream of user trips

--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -1,0 +1,18 @@
+import 'package:firebase_auth/firebase_auth.dart';
+
+/// Service wrapper around [FirebaseAuth] to allow dependency injection
+/// and simplify authentication-related operations.
+class AuthService {
+  const AuthService(this._firebaseAuth);
+
+  final FirebaseAuth _firebaseAuth;
+
+  /// Currently authenticated user or `null` if not signed in.
+  User? get currentUser => _firebaseAuth.currentUser;
+
+  /// Stream of authentication state changes.
+  Stream<User?> authStateChanges() => _firebaseAuth.authStateChanges();
+
+  /// Sign the current user out.
+  Future<void> signOut() => _firebaseAuth.signOut();
+}

--- a/lib/services/firestore_service.dart
+++ b/lib/services/firestore_service.dart
@@ -243,6 +243,7 @@ class FirestoreService {
     required String dayId,
     required Place place,
     int? position,
+    String? userId,
   }) async {
     // Check if placeId is empty to avoid Firestore error
     if (place.placeId.isEmpty) {
@@ -250,7 +251,6 @@ class FirestoreService {
       return;
     }
 
-    final userId = FirebaseAuth.instance.currentUser?.uid;
     final placesRef = _firestore
         .collection('trips')
         .doc(tripId)

--- a/lib/services/groups_service.dart
+++ b/lib/services/groups_service.dart
@@ -1,14 +1,15 @@
-import 'package:firebase_auth/firebase_auth.dart';
+import 'auth_service.dart';
 
 import 'firestore_service.dart';
 
 class GroupsService {
-  GroupsService(this._firestoreService);
+  GroupsService(this._firestoreService, this._authService);
 
   final FirestoreService _firestoreService;
+  final AuthService _authService;
 
   // Get current user ID
-  String? get _currentUserId => FirebaseAuth.instance.currentUser?.uid;
+  String? get _currentUserId => _authService.currentUser?.uid;
 
   // Stream groups feedback summary
   Stream<Map<String, dynamic>?> streamGroupsFeedbackSummary() {

--- a/lib/services/traveler_profile_service.dart
+++ b/lib/services/traveler_profile_service.dart
@@ -1,15 +1,16 @@
-import 'package:firebase_auth/firebase_auth.dart';
+import 'auth_service.dart';
 
 import '../models/traveler_profile.dart';
 import 'firestore_service.dart';
 
 class TravelerProfileService {
-  TravelerProfileService(this._firestoreService);
+  TravelerProfileService(this._firestoreService, this._authService);
 
   final FirestoreService _firestoreService;
+  final AuthService _authService;
 
   /// Get the current user ID
-  String? get _currentUserId => FirebaseAuth.instance.currentUser?.uid;
+  String? get _currentUserId => _authService.currentUser?.uid;
 
   /// Get the saved traveler profile
   Future<TravelerProfile?> getProfile() async {

--- a/lib/services/trip_service.dart
+++ b/lib/services/trip_service.dart
@@ -1,4 +1,3 @@
-import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:travel_genie/services/day_summary_service.dart';
 
@@ -6,21 +5,24 @@ import '../models/itinerary_day.dart';
 import '../models/place.dart';
 import '../models/trip.dart';
 import 'firestore_service.dart';
+import 'auth_service.dart';
 
 class TripService {
   final FirestoreService _firestoreService;
   final DaySummaryService _daySummaryService;
+  final AuthService _authService;
   final String? _languageCode;
 
   TripService(
     this._firestoreService,
     this._daySummaryService,
+    this._authService,
     this._languageCode,
   );
 
   /// Stream trips for the current user
   Stream<List<Trip>> getUserTrips() {
-    final user = FirebaseAuth.instance.currentUser;
+    final user = _authService.currentUser;
 
     // If no user is logged in, return an empty list
     if (user == null) {
@@ -39,7 +41,7 @@ class TripService {
     required DateTime endDate,
     bool isArchived = false,
   }) async {
-    final user = FirebaseAuth.instance.currentUser;
+    final user = _authService.currentUser;
     if (user == null) {
       throw Exception('User not logged in');
     }
@@ -70,7 +72,7 @@ class TripService {
   }
 
   Stream<List<Place>> streamSavedPlacesForCurrentUser() {
-    final user = FirebaseAuth.instance.currentUser;
+    final user = _authService.currentUser;
     if (user == null) return const Stream.empty();
     return _firestoreService.streamSavedPlacesAsPlaces(user.uid);
   }
@@ -87,6 +89,7 @@ class TripService {
           dayId: dayId,
           place: place,
           position: position,
+          userId: _authService.currentUser?.uid,
         )
         .then((onValue) {
           _daySummaryService

--- a/lib/services/user_deletion_service.dart
+++ b/lib/services/user_deletion_service.dart
@@ -1,15 +1,17 @@
 import 'dart:convert';
 
-import 'package:firebase_auth/firebase_auth.dart';
+import 'auth_service.dart';
 import 'package:http/http.dart' as http;
 import 'package:travel_genie/models/user_deletion_request.dart';
 import 'package:travel_genie/models/user_deletion_response.dart';
 
 class UserDeletionService {
-  UserDeletionService({http.Client? client})
-    : _client = client ?? http.Client();
+  UserDeletionService({http.Client? client, required AuthService authService})
+      : _client = client ?? http.Client(),
+        _authService = authService;
 
   final http.Client _client;
+  final AuthService _authService;
 
   // Base URL following the pattern from other services
   static const String baseUrl =
@@ -19,7 +21,7 @@ class UserDeletionService {
   Future<UserDeletionResponse> deleteAllUserData(String userId) async {
     try {
       // Get the current Firebase user and ID token
-      final User? currentUser = FirebaseAuth.instance.currentUser;
+      final User? currentUser = _authService.currentUser;
       if (currentUser == null) {
         throw Exception('User not authenticated');
       }

--- a/lib/services/user_management_service.dart
+++ b/lib/services/user_management_service.dart
@@ -3,8 +3,8 @@ import 'package:travel_genie/models/user_deletion_response.dart';
 import 'package:travel_genie/services/user_deletion_service.dart';
 
 class UserManagementService {
-  UserManagementService({UserDeletionService? userDeletionService})
-    : _userDeletionService = userDeletionService ?? UserDeletionService();
+  UserManagementService({required UserDeletionService userDeletionService})
+      : _userDeletionService = userDeletionService;
 
   final UserDeletionService _userDeletionService;
 

--- a/lib/widgets/home/gamification_progress_section.dart
+++ b/lib/widgets/home/gamification_progress_section.dart
@@ -1,4 +1,3 @@
-import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -6,13 +5,14 @@ import 'package:go_router/go_router.dart';
 import '../../l10n/app_localizations.dart';
 import '../../models/challenge.dart';
 import '../../providers/challenge_providers.dart';
+import '../../services/auth_service.dart';
 
 class GamificationProgressSection extends ConsumerWidget {
   const GamificationProgressSection({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final user = FirebaseAuth.instance.currentUser;
+    final user = ref.watch(authServiceProvider).currentUser;
 
     return InkWell(
       onTap: () => context.go('/profile'),

--- a/lib/widgets/profile/dark_mode_toggle_tile.dart
+++ b/lib/widgets/profile/dark_mode_toggle_tile.dart
@@ -1,16 +1,16 @@
-import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../l10n/app_localizations.dart';
 import '../../providers/user_providers.dart';
+import '../../services/auth_service.dart';
 
 class DarkModeToggleTile extends ConsumerWidget {
   const DarkModeToggleTile({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final user = FirebaseAuth.instance.currentUser;
+    final user = ref.watch(authServiceProvider).currentUser;
     final locale = ref.watch(localeProvider);
     final themeMode = ref.watch(themeModeProvider);
     final service = ref.read(firestoreServiceProvider);

--- a/lib/widgets/profile/language_settings_tile.dart
+++ b/lib/widgets/profile/language_settings_tile.dart
@@ -1,16 +1,16 @@
-import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../l10n/app_localizations.dart';
 import '../../providers/user_providers.dart';
+import '../../services/auth_service.dart';
 
 class LanguageSettingsTile extends ConsumerWidget {
   const LanguageSettingsTile({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final user = FirebaseAuth.instance.currentUser;
+    final user = ref.watch(authServiceProvider).currentUser;
     final locale = ref.watch(localeProvider);
     final themeMode = ref.watch(themeModeProvider);
     final service = ref.read(firestoreServiceProvider);

--- a/lib/widgets/profile/logout_tile.dart
+++ b/lib/widgets/profile/logout_tile.dart
@@ -1,9 +1,9 @@
-import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../l10n/app_localizations.dart';
 import '../../user_providers.dart';
+import '../../services/auth_service.dart';
 
 class LogoutTile extends ConsumerWidget {
   const LogoutTile({super.key});
@@ -14,7 +14,7 @@ class LogoutTile extends ConsumerWidget {
       leading: const Icon(Icons.logout),
       title: Text(AppLocalizations.of(context)!.logout),
       onTap: () async {
-        await FirebaseAuth.instance.signOut();
+        await ref.read(authServiceProvider).signOut();
         final prefs = await ref.read(preferencesServiceProvider.future);
         await prefs.clearAll();
         if (context.mounted) {

--- a/lib/widgets/search_results/search_result_card.dart
+++ b/lib/widgets/search_results/search_result_card.dart
@@ -1,5 +1,4 @@
 import 'package:cached_network_image/cached_network_image.dart';
-import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -9,6 +8,7 @@ import '../../core/extensions/string_extension.dart';
 import '../../l10n/app_localizations.dart';
 import '../../models/place.dart';
 import '../../providers/user_providers.dart';
+import '../../services/auth_service.dart';
 import '../login_required_dialog.dart';
 import 'photo_attribution.dart';
 
@@ -40,7 +40,7 @@ class _SearchResultCardState extends ConsumerState<SearchResultCard> {
 
   Future<void> _checkIfSaved() async {
     try {
-      final user = FirebaseAuth.instance.currentUser;
+      final user = ref.read(authServiceProvider).currentUser;
       if (user != null) {
         try {
           final firestoreService = ref.read(firestoreServiceProvider);
@@ -68,7 +68,7 @@ class _SearchResultCardState extends ConsumerState<SearchResultCard> {
     try {
       User? user;
       try {
-        user = FirebaseAuth.instance.currentUser;
+        user = ref.read(authServiceProvider).currentUser;
         if (user == null) {
           // Show login required dialog
           if (mounted) {


### PR DESCRIPTION
## Summary
- add `AuthService` wrapper for FirebaseAuth
- inject `AuthService` into services that previously read `FirebaseAuth` directly
- update providers and widgets to use `AuthService`
- refactor `ItineraryDragDropService` to receive `TripService` via constructor

## Testing
- `flutter format lib/services/itinerary_drag_drop_service.dart lib/widgets/profile/language_settings_tile.dart lib/widgets/profile/dark_mode_toggle_tile.dart lib/widgets/profile/logout_tile.dart lib/widgets/home/gamification_progress_section.dart lib/widgets/search_results/search_result_card.dart lib/pages/create_trip_page.dart lib/pages/my_trips_page.dart lib/pages/place_detail_page.dart lib/pages/profile_screen.dart lib/providers/challenge_providers.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686224931a9c83308662e5814f4ca783