### PR TITLE
Refactor challenge actions and UI widgets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,4 +47,4 @@ app.*.map.json
 /android/app/profile
 /android/app/release
 
-proven-aviary-434423-s1-596a1d9f6dcc.json
+proven-aviary-434423-s1-596a1d9f6dcc.jsonflutter_linux_*.tar.xz

--- a/lib/providers/challenge_providers.dart
+++ b/lib/providers/challenge_providers.dart
@@ -5,6 +5,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../models/challenge.dart';
 import '../services/challenge_progress_service.dart';
 import '../services/challenge_service.dart';
+import '../services/challenge_actions_service.dart';
 
 /// Provider for ChallengeService
 final challengeServiceProvider = Provider<ChallengeService>((ref) {
@@ -85,61 +86,7 @@ final challengeWithProgressProvider = StreamProvider.family<Challenge?, String>(
 );
 
 /// Provider for challenge actions (updating progress, marking complete, etc.)
-final challengeActionsProvider = Provider<ChallengeActions>((ref) {
+final challengeActionsProvider = Provider<ChallengeActionsService>((ref) {
   final progressService = ref.watch(challengeProgressServiceProvider);
-  return ChallengeActions(progressService);
+  return ChallengeActionsService(progressService);
 });
-
-/// Class that provides actions for challenge management
-class ChallengeActions {
-  ChallengeActions(this._progressService);
-
-  final ChallengeProgressService _progressService;
-
-  /// Update progress for a challenge
-  Future<void> updateProgress(
-    String userId,
-    String challengeId,
-    int newProgress,
-  ) async {
-    await _progressService.updateChallengeProgress(
-      userId,
-      challengeId,
-      newProgress,
-    );
-  }
-
-  /// Increment progress for a challenge
-  Future<void> incrementProgress(
-    String userId,
-    String challengeId, {
-    int increment = 1,
-  }) async {
-    await _progressService.incrementChallengeProgress(
-      userId,
-      challengeId,
-      increment: increment,
-    );
-  }
-
-  /// Mark a challenge as completed
-  Future<void> markCompleted(String userId, String challengeId) async {
-    await _progressService.markChallengeCompleted(userId, challengeId);
-  }
-
-  /// Reset progress for a challenge
-  Future<void> resetProgress(String userId, String challengeId) async {
-    await _progressService.resetChallengeProgress(userId, challengeId);
-  }
-
-  /// Initialize progress for a new user
-  Future<void> initializeUserProgress(
-    String userId,
-    List<String> challengeIds,
-  ) async {
-    await _progressService.initializeUserChallengeProgress(
-      userId,
-      challengeIds,
-    );
-  }
-}

--- a/lib/services/challenge_actions_service.dart
+++ b/lib/services/challenge_actions_service.dart
@@ -1,0 +1,55 @@
+import 'challenge_progress_service.dart';
+
+/// Service providing actions for managing challenge progress.
+class ChallengeActionsService {
+  ChallengeActionsService(this._progressService);
+
+  final ChallengeProgressService _progressService;
+
+  /// Update progress for a challenge.
+  Future<void> updateProgress(
+    String userId,
+    String challengeId,
+    int newProgress,
+  ) async {
+    await _progressService.updateChallengeProgress(
+      userId,
+      challengeId,
+      newProgress,
+    );
+  }
+
+  /// Increment progress for a challenge.
+  Future<void> incrementProgress(
+    String userId,
+    String challengeId, {
+    int increment = 1,
+  }) async {
+    await _progressService.incrementChallengeProgress(
+      userId,
+      challengeId,
+      increment: increment,
+    );
+  }
+
+  /// Mark a challenge as completed.
+  Future<void> markCompleted(String userId, String challengeId) async {
+    await _progressService.markChallengeCompleted(userId, challengeId);
+  }
+
+  /// Reset progress for a challenge.
+  Future<void> resetProgress(String userId, String challengeId) async {
+    await _progressService.resetChallengeProgress(userId, challengeId);
+  }
+
+  /// Initialize progress for a new user.
+  Future<void> initializeUserProgress(
+    String userId,
+    List<String> challengeIds,
+  ) async {
+    await _progressService.initializeUserChallengeProgress(
+      userId,
+      challengeIds,
+    );
+  }
+}

--- a/lib/widgets/groups/example_row.dart
+++ b/lib/widgets/groups/example_row.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/material.dart';
+
+/// Row widget used in feedback examples list.
+class ExampleRow extends StatelessWidget {
+  const ExampleRow({
+    super.key,
+    required this.emoji,
+    required this.text,
+  });
+
+  final String emoji;
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Row(
+      children: [
+        Text(emoji, style: const TextStyle(fontSize: 16)),
+        const SizedBox(width: 8),
+        Expanded(
+          child: Text(
+            text,
+            style: theme.textTheme.bodyMedium?.copyWith(
+              color: theme.colorScheme.onTertiaryContainer.withOpacity(0.8),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/widgets/groups/feedback_card.dart
+++ b/lib/widgets/groups/feedback_card.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import '../../l10n/app_localizations.dart';
+import 'example_row.dart';
 
 class FeedbackCard extends StatelessWidget {
   const FeedbackCard({
@@ -96,28 +97,24 @@ class FeedbackCard extends StatelessWidget {
                     ],
                   ),
                   const SizedBox(height: 12),
-                  _buildExampleRow(
-                    context,
-                    '👨‍👩‍👧‍👦',
-                    l10n.groupsFeedbackExampleFamily,
+                  ExampleRow(
+                    emoji: '👨‍👩‍👧‍👦',
+                    text: l10n.groupsFeedbackExampleFamily,
                   ),
                   const SizedBox(height: 8),
-                  _buildExampleRow(
-                    context,
-                    '👥',
-                    l10n.groupsFeedbackExampleFriends,
+                  ExampleRow(
+                    emoji: '👥',
+                    text: l10n.groupsFeedbackExampleFriends,
                   ),
                   const SizedBox(height: 8),
-                  _buildExampleRow(
-                    context,
-                    '💼',
-                    l10n.groupsFeedbackExampleColleagues,
+                  ExampleRow(
+                    emoji: '💼',
+                    text: l10n.groupsFeedbackExampleColleagues,
                   ),
                   const SizedBox(height: 8),
-                  _buildExampleRow(
-                    context,
-                    '💕',
-                    l10n.groupsFeedbackExamplePartner,
+                  ExampleRow(
+                    emoji: '💕',
+                    text: l10n.groupsFeedbackExamplePartner,
                   ),
                 ],
               ),
@@ -166,21 +163,4 @@ class FeedbackCard extends StatelessWidget {
     );
   }
 
-  Widget _buildExampleRow(BuildContext context, String emoji, String text) {
-    final theme = Theme.of(context);
-    return Row(
-      children: [
-        Text(emoji, style: const TextStyle(fontSize: 16)),
-        const SizedBox(width: 8),
-        Expanded(
-          child: Text(
-            text,
-            style: theme.textTheme.bodyMedium?.copyWith(
-              color: theme.colorScheme.onTertiaryContainer.withOpacity(0.8),
-            ),
-          ),
-        ),
-      ],
-    );
-  }
 }

--- a/lib/widgets/groups/feedback_stat_card.dart
+++ b/lib/widgets/groups/feedback_stat_card.dart
@@ -1,0 +1,62 @@
+import 'package:flutter/material.dart';
+
+/// Card widget showing a single feedback statistic.
+class FeedbackStatCard extends StatelessWidget {
+  const FeedbackStatCard({
+    super.key,
+    required this.icon,
+    required this.label,
+    required this.count,
+    required this.percentage,
+    required this.color,
+    required this.backgroundColor,
+  });
+
+  final IconData icon;
+  final String label;
+  final int count;
+  final int percentage;
+  final Color color;
+  final Color backgroundColor;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Container(
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: backgroundColor.withOpacity(0.3),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: color.withOpacity(0.3), width: 1),
+      ),
+      child: Column(
+        children: [
+          Icon(icon, color: color, size: 24),
+          const SizedBox(height: 8),
+          Text(
+            '$count',
+            style: theme.textTheme.headlineSmall?.copyWith(
+              fontWeight: FontWeight.bold,
+              color: color,
+            ),
+          ),
+          Text(
+            '$percentage%',
+            style: theme.textTheme.bodySmall?.copyWith(
+              color: color.withOpacity(0.8),
+              fontWeight: FontWeight.w500,
+            ),
+          ),
+          const SizedBox(height: 4),
+          Text(
+            label,
+            style: theme.textTheme.bodySmall?.copyWith(
+              color: theme.colorScheme.onSurface.withOpacity(0.7),
+            ),
+            textAlign: TextAlign.center,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/widgets/groups/feedback_summary.dart
+++ b/lib/widgets/groups/feedback_summary.dart
@@ -157,8 +157,7 @@ class FeedbackSummary extends StatelessWidget {
             Row(
               children: [
                 Expanded(
-                  child: _buildStatCard(
-                    context,
+                  child: FeedbackStatCard(
                     icon: Icons.thumb_up_rounded,
                     label: l10n.groupsFeedbackYes,
                     count: yesCount,
@@ -169,8 +168,7 @@ class FeedbackSummary extends StatelessWidget {
                 ),
                 const SizedBox(width: 12),
                 Expanded(
-                  child: _buildStatCard(
-                    context,
+                  child: FeedbackStatCard(
                     icon: Icons.thumb_down_rounded,
                     label: l10n.groupsFeedbackNo,
                     count: noCount,
@@ -213,54 +211,6 @@ class FeedbackSummary extends StatelessWidget {
     );
   }
 
-  Widget _buildStatCard(
-    BuildContext context, {
-    required IconData icon,
-    required String label,
-    required int count,
-    required int percentage,
-    required Color color,
-    required Color backgroundColor,
-  }) {
-    final theme = Theme.of(context);
-
-    return Container(
-      padding: const EdgeInsets.all(16),
-      decoration: BoxDecoration(
-        color: backgroundColor.withOpacity(0.3),
-        borderRadius: BorderRadius.circular(12),
-        border: Border.all(color: color.withOpacity(0.3), width: 1),
-      ),
-      child: Column(
-        children: [
-          Icon(icon, color: color, size: 24),
-          const SizedBox(height: 8),
-          Text(
-            '$count',
-            style: theme.textTheme.headlineSmall?.copyWith(
-              fontWeight: FontWeight.bold,
-              color: color,
-            ),
-          ),
-          Text(
-            '$percentage%',
-            style: theme.textTheme.bodySmall?.copyWith(
-              color: color.withOpacity(0.8),
-              fontWeight: FontWeight.w500,
-            ),
-          ),
-          const SizedBox(height: 4),
-          Text(
-            label,
-            style: theme.textTheme.bodySmall?.copyWith(
-              color: theme.colorScheme.onSurface.withOpacity(0.7),
-            ),
-            textAlign: TextAlign.center,
-          ),
-        ],
-      ),
-    );
-  }
 
   String _getEncouragingMessage(BuildContext context, int yesPercentage) {
     final l10n = AppLocalizations.of(context);


### PR DESCRIPTION
## Summary
- extract `ChallengeActionsService` from provider
- refactor challenge provider to use the new service
- refactor `FeedbackSummary` and `FeedbackCard` builder methods into widgets
- add `FeedbackStatCard` and `ExampleRow` widgets
- ignore Flutter tarballs in repo

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686294854e0c83309a7903f4440191f6