### PR TITLE
Refactor gamification progress section

### DIFF
--- a/lib/core/extensions/challenge_localization_extension.dart
+++ b/lib/core/extensions/challenge_localization_extension.dart
@@ -1,0 +1,40 @@
+import '../../l10n/app_localizations.dart';
+
+/// Extension to resolve challenge localization keys to localized strings.
+extension ChallengeLocalizationExtension on AppLocalizations {
+  /// Returns the localized title for the given [key].
+  String challengeTitleFromKey(String key) {
+    switch (key) {
+      case 'challengeCreateAccountTitle':
+        return challengeCreateAccountTitle;
+      case 'challengeCompleteProfileTitle':
+        return challengeCompleteProfileTitle;
+      case 'challengeCreateTripTitle':
+        return challengeCreateTripTitle;
+      case 'challengeSavePlaceTitle':
+        return challengeSavePlaceTitle;
+      case 'challengeGenerateItineraryTitle':
+        return challengeGenerateItineraryTitle;
+      default:
+        return key;
+    }
+  }
+
+  /// Returns the localized description for the given [key].
+  String challengeDescriptionFromKey(String key) {
+    switch (key) {
+      case 'challengeCreateAccountDescription':
+        return challengeCreateAccountDescription;
+      case 'challengeCompleteProfileDescription':
+        return challengeCompleteProfileDescription;
+      case 'challengeCreateTripDescription':
+        return challengeCreateTripDescription;
+      case 'challengeSavePlaceDescription':
+        return challengeSavePlaceDescription;
+      case 'challengeGenerateItineraryDescription':
+        return challengeGenerateItineraryDescription;
+      default:
+        return key;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- refactor `GamificationProgressSection` to follow widget best practices
- add `ChallengeProgressContent` and `ChallengeItem` widgets
- introduce `ChallengeLocalizationExtension` for mapping localization keys

## Testing
- `../flutter/bin/flutter test` *(fails: Some tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_6862a204ee448330b1bdd133cb3a3c9e